### PR TITLE
clientv1_tokens: use 3 seconds idle conn timeout for token introspection

### DIFF
--- a/clientv1_tokens.go
+++ b/clientv1_tokens.go
@@ -57,9 +57,13 @@ func (s *TokensServiceV1) IntrospectToken(ctx context.Context, token string) (*I
 	basicAuth := base64.StdEncoding.EncodeToString([]byte(credentialStr))
 	req.Header.Set("Authorization", "Basic "+basicAuth)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	// NOTE: Always create a new client to avoid unintended global idle connection
-	// sharing (http.DefaultClient).
-	httpClient := &http.Client{}
+	// Use a much shorter idle connection timeout than the default to avoid being
+	// idle for too long and force killed by Cloud Run.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.IdleConnTimeout = 3 * time.Second
+	httpClient := &http.Client{
+		Transport: transport,
+	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "request introspection endpoint")


### PR DESCRIPTION
Previous experiment with always creating a new client did not work out https://github.com/sourcegraph/sourcegraph-accounts-sdk-go/pull/3, trying to forcefully setting a much short idle conn timeout value (3s).

## Test plan

CI