### PR TITLE
Register new scope 'cody_gateway::flaggedprompts::*'

### DIFF
--- a/scopes/scopes.go
+++ b/scopes/scopes.go
@@ -89,6 +89,9 @@ func ToScope(service Service, permission Permission, action Action) Scope {
 type Permission string
 
 var (
+	codyGatewayPermissions = []Permission{
+		"flaggedprompts",
+	}
 	samsPermissions = []Permission{
 		"user",
 		"user.profile",
@@ -101,9 +104,6 @@ var (
 	}
 	telemetryGatewayPermissions = []Permission{
 		"events",
-	}
-	codyGatewayPermissions = []Permission{
-		"flaggedprompts",
 	}
 )
 

--- a/scopes/scopes.go
+++ b/scopes/scopes.go
@@ -33,6 +33,7 @@ type Service string
 
 // The list of registered services that publishes scopes.
 const (
+	ServiceCodyGateway      Service = "cody_gateway"
 	ServiceSAMS             Service = "sams"
 	ServiceTelemetryGateway Service = "telemetry_gateway"
 )
@@ -101,6 +102,9 @@ var (
 	telemetryGatewayPermissions = []Permission{
 		"events",
 	}
+	codyGatewayPermissions = []Permission{
+		"flaggedprompts",
+	}
 )
 
 // Allowed returns all allowed scopes for a client. The caller should use
@@ -129,9 +133,10 @@ func Allowed() AllowedScopes {
 		}
 	}
 
+	appendScopes(ServiceCodyGateway, codyGatewayPermissions)
 	appendScopes(ServiceSAMS, samsPermissions)
 	appendScopes(ServiceTelemetryGateway, telemetryGatewayPermissions)
-	// 👉ADD YOUR SCOPES HERE
+	// 👉 ADD YOUR SCOPES HERE
 	return allowed
 }
 


### PR DESCRIPTION
As part of some work I'm doing with battling abuse in Cody Gateway, I registered a new SAMS-authenticated REST API https://github.com/sourcegraph/sourcegraph/pull/61514/files. This new REST API performs authentication by looking for the `"cody_gateway::flaggedprompts::read"` scope.

No SAMS clients have that scope yet. Nor can I register one until after merging this PR and getting it integrated into `Sourcegraph-accounts`, and then deploying that to production.

... but once that is done, I'll register a new SAMS Client for `abuse-ban-bot`, and add that as one of the scopes the client is able to request. Thereby allowing to be make use of these new APIs.

## Test plan

NA