### PR TITLE
clientv1: add ClientV1ConnConfig type with standardized env loading

### DIFF
--- a/clientv1.go
+++ b/clientv1.go
@@ -72,9 +72,13 @@ func (c ClientV1ConnConfig) Validate() error {
 	if c.getAPIURL() == "" {
 		return errors.New("evaluated API URL is empty")
 	}
-	if c.ClientID == "" || c.ClientSecret == "" {
-		return errors.New("empty client ID or secret")
+	if c.ClientID == "" {
+		return errors.New("empty client ID")
 	}
+	if c.ClientSecret == "" {
+		return errors.New("empty client secret")
+	}
+	
 	return nil
 }
 

--- a/clientv1.go
+++ b/clientv1.go
@@ -26,14 +26,71 @@ type ClientV1 struct {
 	defaultInterceptors []connect.Interceptor
 }
 
+type ClientV1ConnConfig struct {
+	// ExternalURL is the configured default external ExternalURL of the relevant Sourcegraph
+	// Accounts instance.
+	ExternalURL string
+	// APIURL is the URL to use for Sourcegraph Accounts API interactions. This
+	// can be set to some internal URLs for private networking. If this is nil,
+	// the client will fall back to URL instead.
+	APIURL *string
+	// Client credentials representing this Sourcegraph Accounts client
+	ClientID     string
+	ClientSecret string
+}
+
+// envGetter is a helper interface for getting environment variables based on
+// the MSP runtime environment, matching the type
+// github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime/contract.Env.
+type envGetter interface {
+	// Get returns the value with the given name. If no value was supplied in the
+	// environment, the given default is used in its place. If no value is available,
+	// an error is added to the validation errors list.
+	Get(name, defaultValue, description string) string
+	// GetOptional returns the value with the given name, or nil if no value is
+	// available.
+	GetOptional(name, description string) *string
+}
+
+const defaultExternalURL = "https://accounts.sourcegraph.com"
+
+// NewClientV1ConnectionConfigFromEnv initializes configuration for connecting
+// to Sourcegraph Accounts using default standards for loading environment
+// variables. This allows the Core Services team to more easily configure access.
+func NewClientV1ConnectionConfigFromEnv(env envGetter) (c ClientV1ConnConfig) {
+	c.ExternalURL = env.Get("SAMS_URL", defaultExternalURL, "External URL of the connected SAMS instance")
+	c.APIURL = env.GetOptional("SAMS_API_URL", "URL to use for connecting to the API of a SAMS instance instead of SAMS_URL")
+	c.ClientID = env.Get("SAMS_CLIENT_ID", "", "Client ID of the SAMS client")
+	c.ClientSecret = env.Get("SAMS_CLIENT_SECRET", "", "Client secret of the SAMS client")
+	return c
+}
+
+func (c ClientV1ConnConfig) Validate() error {
+	if c.ExternalURL == "" {
+		return errors.New("empty external URL")
+	}
+	if c.getAPIURL() == "" {
+		return errors.New("evaluated API URL is empty")
+	}
+	if c.ClientID == "" || c.ClientSecret == "" {
+		return errors.New("empty client ID or secret")
+	}
+	return nil
+}
+
+func (c ClientV1ConnConfig) getAPIURL() string {
+	if c.APIURL != nil {
+		return *c.APIURL
+	}
+	return c.ExternalURL
+}
+
 // NewClientV1 returns a new SAMS client for interacting with Clients API v1
 // using the given client credentials, and the scopes are used to as requested
 // scopes for access tokens that are issued to this client.
-func NewClientV1(url, clientID, clientSecret string, scopeList []scopes.Scope) (*ClientV1, error) {
-	if url == "" {
-		return nil, errors.New("empty URL")
-	} else if clientID == "" || clientSecret == "" {
-		return nil, errors.New("empty client ID or secret")
+func NewClientV1(config ClientV1ConnConfig, scopeList []scopes.Scope) (*ClientV1, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Wrap(err, "ClientV1ConnectionConfig is invalid")
 	}
 
 	otelinterceptor, err := otelconnect.NewInterceptor(
@@ -45,14 +102,15 @@ func NewClientV1(url, clientID, clientSecret string, scopeList []scopes.Scope) (
 		return nil, errors.Wrap(err, "initiate OTEL interceptor")
 	}
 
+	apiURL := config.getAPIURL()
 	clientCredentialsConfig := clientcredentials.Config{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		TokenURL:     fmt.Sprintf("%s/oauth/token", url),
+		ClientID:     config.ClientID,
+		ClientSecret: config.ClientSecret,
+		TokenURL:     fmt.Sprintf("%s/oauth/token", apiURL),
 		Scopes:       scopes.ToStrings(scopeList),
 	}
 	return &ClientV1{
-		rootURL:                 strings.TrimSuffix(url, "/"),
+		rootURL:                 strings.TrimSuffix(apiURL, "/"),
 		clientCredentialsConfig: clientCredentialsConfig,
 		tokenSource:             clientCredentialsConfig.TokenSource(context.Background()),
 

--- a/clientv1.go
+++ b/clientv1.go
@@ -32,7 +32,7 @@ type ClientV1ConnConfig struct {
 	ExternalURL string
 	// APIURL is the URL to use for Sourcegraph Accounts API interactions. This
 	// can be set to some internal URLs for private networking. If this is nil,
-	// the client will fall back to URL instead.
+	// the client will fall back to ExternalURL instead.
 	APIURL *string
 	// Client credentials representing this Sourcegraph Accounts client
 	ClientID     string

--- a/clientv1_test.go
+++ b/clientv1_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
+	"github.com/hexops/autogold/v2"
+	"github.com/hexops/valast"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 	"github.com/stretchr/testify/assert"
@@ -13,11 +15,104 @@ import (
 	"github.com/sourcegraph/sourcegraph-accounts-sdk-go/scopes"
 )
 
+type staticEnvGetter map[string]string
+
+func (e staticEnvGetter) Get(name, defaultValue, _ string) string {
+	v, ok := e[name]
+	if !ok {
+		return defaultValue
+	}
+	return v
+}
+
+func (e staticEnvGetter) GetOptional(name, description string) *string {
+	v := e.Get(name, "", description)
+	if v == "" {
+		return nil
+	}
+	return &v
+}
+
+func TestNewClientV1ConnectionConfigFromEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  staticEnvGetter
+
+		want            autogold.Value
+		wantValidateErr autogold.Value
+	}{
+		{
+			name:            "no env",
+			env:             staticEnvGetter{},
+			want:            autogold.Expect(ClientV1ConnConfig{ExternalURL: "https://accounts.sourcegraph.com"}),
+			wantValidateErr: autogold.Expect("empty client ID or secret"),
+		},
+		{
+			name: "only client credentials",
+			env: staticEnvGetter{
+				"SAMS_CLIENT_ID":     "fooclient",
+				"SAMS_CLIENT_SECRET": "barsecret",
+			},
+			want: autogold.Expect(ClientV1ConnConfig{
+				ExternalURL:  "https://accounts.sourcegraph.com",
+				ClientID:     "fooclient",
+				ClientSecret: "barsecret",
+			}),
+		},
+		{
+			name: "override API URL",
+			env: staticEnvGetter{
+				"SAMS_API_URL":       "https://my-internal-url.net",
+				"SAMS_CLIENT_ID":     "fooclient",
+				"SAMS_CLIENT_SECRET": "barsecret",
+			},
+			want: autogold.Expect(ClientV1ConnConfig{
+				ExternalURL:  "https://accounts.sourcegraph.com",
+				APIURL:       valast.Addr("https://my-internal-url.net").(*string),
+				ClientID:     "fooclient",
+				ClientSecret: "barsecret",
+			}),
+		},
+		{
+			name: "set all",
+			env: staticEnvGetter{
+				"SAMS_URL":           "https://my-external-url.net",
+				"SAMS_API_URL":       "https://my-internal-url.net",
+				"SAMS_CLIENT_ID":     "fooclient",
+				"SAMS_CLIENT_SECRET": "barsecret",
+			},
+			want: autogold.Expect(ClientV1ConnConfig{
+				ExternalURL:  "https://my-external-url.net",
+				APIURL:       valast.Addr("https://my-internal-url.net").(*string),
+				ClientID:     "fooclient",
+				ClientSecret: "barsecret",
+			}),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewClientV1ConnectionConfigFromEnv(tc.env)
+			tc.want.Equal(t, got)
+
+			t.Run("Validate", func(t *testing.T) {
+				err := got.Validate()
+				if tc.wantValidateErr != nil {
+					require.Error(t, err)
+					tc.wantValidateErr.Equal(t, err.Error())
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		})
+	}
+}
+
 func TestNewClientV1(t *testing.T) {
 	c, err := NewClientV1(
-		"https://accounts.sourcegraph.com",
-		"fooclient",
-		"barsecret",
+		ClientV1ConnConfig{
+			ExternalURL:  "https://accounts.sourcegraph.com",
+			ClientID:     "fooclient",
+			ClientSecret: "barsecret",
+		},
 		[]scopes.Scope{scopes.Profile})
 	require.NoError(t, err)
 	assert.NotEmpty(t, c.defaultInterceptors)

--- a/clientv1_test.go
+++ b/clientv1_test.go
@@ -45,7 +45,7 @@ func TestNewClientV1ConnectionConfigFromEnv(t *testing.T) {
 			name:            "no env",
 			env:             staticEnvGetter{},
 			want:            autogold.Expect(ClientV1ConnConfig{ExternalURL: "https://accounts.sourcegraph.com"}),
-			wantValidateErr: autogold.Expect("empty client ID or secret"),
+			wantValidateErr: autogold.Expect("empty client ID"),
 		},
 		{
 			name: "only client credentials",

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/hexops/autogold/v2 v2.0.3
+	github.com/hexops/valast v1.4.3
 	github.com/lestrrat-go/jwx/v2 v2.0.21
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20240315183013-b2b134e08ada
 	github.com/stretchr/testify v1.9.0
@@ -32,7 +33,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
-	github.com/hexops/valast v1.4.3 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.14.0 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect


### PR DESCRIPTION
Introduces a way to get SAMS client config within MSP runtime in a standardized manner (i.e. as part of `ConfigLoader` implementations). This makes it easier for us to configure custom properties for SAMS clients, namely the API URL for rollout of https://github.com/sourcegraph/managed-services/issues/660, in a more universal manner. Making this runtime-compatible also adds these env dependencies to runtime `-help` etc - callers can make their own trivial `env.Get` shims if needed.

Configuring this in env also allows us to do e.g. manual partial rollouts to N% of traffic to start off.

## Test plan

Unit tests