### PR TITLE
sams: unify conn config (again), add sams.NewAccountsV1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sourcegraph Accounts SDK for Go
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/sourcegraph/sourcegraph-accounts-sdk-go.svg)](https://pkg.go.dev/github.com/sourcegraph/sourcegraph-accounts-sdk-go) [![Go](https://github.com/sourcegraph/sourcegraph-accounts-sdk-go/actions/workflows/go.yml/badge.svg)](https://github.com/sourcegraph/sourcegraph-accounts-sdk-go/actions/workflows/go.yml)
+
 This repository contains the Go SDK for integrating with [Sourcegraph Accounts Management System (SAMS)](https://handbook.sourcegraph.com/departments/engineering/teams/core-services/sams/).
 
 ```zsh
@@ -132,18 +134,18 @@ import (
 )
 
 func main() {
-	samsClient, err := sams.NewClientV1(
-		"https://accounts.sourcegraph.com",
-		os.Getenv("SAMS_CLIENT_ID"),
-		os.Getenv("SAMS_CLIENT_SECRET"),
-		[]scopes.Scope{
+	samsClient, err := sams.NewClientV1(sams.ClientV1Config{
+		ConnConfig:   sams.NewConnConfigFromEnv(/* ... */),
+		ClientID:     os.Getenv("SAMS_CLIENT_ID"),
+		ClientSecret: os.Getenv("SAMS_CLIENT_SECRET"),
+		Scopes:       []scopes.Scope{
 			scopes.OpenID,
 			scopes.Profile,
 			scopes.Email,
 			"sams::user.roles::read",
 			"sams::session::read",
 		},
-	)
+	})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -173,7 +175,7 @@ import (
 	"os"
 
 	"golang.org/x/oauth2"
-	accountsv1 "github.com/sourcegraph/sourcegraph-accounts-sdk-go/accounts/v1"
+	sams "github.com/sourcegraph/sourcegraph-accounts-sdk-go"
 )
 
 func main() {
@@ -188,7 +190,10 @@ func main() {
 	}
 	tokenSource := oauth2.StaticTokenSource(t)
 
-	client := accountsv1.NewClient("https://accounts.sourcegraph.com", tokenSource)
+	client := sams.NewAccountsV1(sams.AccountsV1Config{
+		ConnConfig:  sams.NewConnConfigFromEnv(/* ... */),
+		TokenSource: tokenSource,
+	})
 	user, err := client.GetUser(ctx)
 	if err != nil {
 		log.Fatal(err)

--- a/accounts/v1/client.go
+++ b/accounts/v1/client.go
@@ -14,6 +14,8 @@ import (
 
 // NewClient constructs a new SAMS Accounts client, pointed to the supplied SAMS host.
 // e.g. "https://accounts.sourcegraph.com".
+//
+// Users should prefer to use the top-level 'sams.NewAccountsV1' constructor instead.
 func NewClient(samsHost string, tokenSource oauth2.TokenSource) *Client {
 	// Canonicalize the host so we only need to check if it ends in a slash or not once.
 	samsHost = strings.ToLower(samsHost)

--- a/accountsv1.go
+++ b/accountsv1.go
@@ -1,0 +1,36 @@
+package sams
+
+import (
+	accountsv1 "github.com/sourcegraph/sourcegraph-accounts-sdk-go/accounts/v1"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"golang.org/x/oauth2"
+)
+
+type AccountsV1Config struct {
+	ConnConfig
+	// TokenSource is the OAuth2 token source to use for authentication.
+	//
+	// If you have the SAMS user's Refresh token, using the oauth2.TokenSource
+	// abstraction will take care of creating short-lived access tokens as
+	// needed. But if you only have the access token, you will need to use a
+	// StaticTokenSource instead.
+	TokenSource oauth2.TokenSource
+}
+
+func (c AccountsV1Config) Validate() error {
+	if err := c.ConnConfig.Validate(); err != nil {
+		return errors.Wrap(err, "ConnConfig")
+	}
+	if c.TokenSource == nil {
+		return errors.New("token source is required")
+	}
+	return nil
+}
+
+// NewAccountsV1 returns a new SAMS client for interacting with Accounts API V1.
+func NewAccountsV1(config AccountsV1Config) (*accountsv1.Client, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	return accountsv1.NewClient(config.getAPIURL(), config.TokenSource), nil
+}

--- a/clientv1.go
+++ b/clientv1.go
@@ -26,51 +26,21 @@ type ClientV1 struct {
 	defaultInterceptors []connect.Interceptor
 }
 
-type ClientV1ConnConfig struct {
-	// ExternalURL is the configured default external ExternalURL of the relevant Sourcegraph
-	// Accounts instance.
-	ExternalURL string
-	// APIURL is the URL to use for Sourcegraph Accounts API interactions. This
-	// can be set to some internal URLs for private networking. If this is nil,
-	// the client will fall back to ExternalURL instead.
-	APIURL *string
+type ClientV1Config struct {
+	ConnConfig
 	// Client credentials representing this Sourcegraph Accounts client
 	ClientID     string
 	ClientSecret string
+	// Scopes to request for this client. Scopes should be defined using the
+	// available scopes package. All requested scopes must be allowed by
+	// the registered client - see:
+	// https://sourcegraph.notion.site/6cc4a1bd9cb247eea9674dbf9d5ce8c3
+	Scopes []scopes.Scope
 }
 
-// envGetter is a helper interface for getting environment variables based on
-// the MSP runtime environment, matching the type
-// github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime/contract.Env.
-type envGetter interface {
-	// Get returns the value with the given name. If no value was supplied in the
-	// environment, the given default is used in its place. If no value is available,
-	// an error is added to the validation errors list.
-	Get(name, defaultValue, description string) string
-	// GetOptional returns the value with the given name, or nil if no value is
-	// available.
-	GetOptional(name, description string) *string
-}
-
-const defaultExternalURL = "https://accounts.sourcegraph.com"
-
-// NewClientV1ConnectionConfigFromEnv initializes configuration for connecting
-// to Sourcegraph Accounts using default standards for loading environment
-// variables. This allows the Core Services team to more easily configure access.
-func NewClientV1ConnectionConfigFromEnv(env envGetter) (c ClientV1ConnConfig) {
-	c.ExternalURL = env.Get("SAMS_URL", defaultExternalURL, "External URL of the connected SAMS instance")
-	c.APIURL = env.GetOptional("SAMS_API_URL", "URL to use for connecting to the API of a SAMS instance instead of SAMS_URL")
-	c.ClientID = env.Get("SAMS_CLIENT_ID", "", "Client ID of the SAMS client")
-	c.ClientSecret = env.Get("SAMS_CLIENT_SECRET", "", "Client secret of the SAMS client")
-	return c
-}
-
-func (c ClientV1ConnConfig) Validate() error {
-	if c.ExternalURL == "" {
-		return errors.New("empty external URL")
-	}
-	if c.getAPIURL() == "" {
-		return errors.New("evaluated API URL is empty")
+func (c ClientV1Config) Validate() error {
+	if err := c.ConnConfig.Validate(); err != nil {
+		return errors.Wrap(err, "ConnConfig")
 	}
 	if c.ClientID == "" {
 		return errors.New("empty client ID")
@@ -78,21 +48,16 @@ func (c ClientV1ConnConfig) Validate() error {
 	if c.ClientSecret == "" {
 		return errors.New("empty client secret")
 	}
-	
-	return nil
-}
-
-func (c ClientV1ConnConfig) getAPIURL() string {
-	if c.APIURL != nil {
-		return *c.APIURL
+	if len(c.Scopes) == 0 {
+		return errors.New("no scopes requested")
 	}
-	return c.ExternalURL
+	return nil
 }
 
 // NewClientV1 returns a new SAMS client for interacting with Clients API v1
 // using the given client credentials, and the scopes are used to as requested
 // scopes for access tokens that are issued to this client.
-func NewClientV1(config ClientV1ConnConfig, scopeList []scopes.Scope) (*ClientV1, error) {
+func NewClientV1(config ClientV1Config) (*ClientV1, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Wrap(err, "ClientV1ConnectionConfig is invalid")
 	}
@@ -111,7 +76,7 @@ func NewClientV1(config ClientV1ConnConfig, scopeList []scopes.Scope) (*ClientV1
 		ClientID:     config.ClientID,
 		ClientSecret: config.ClientSecret,
 		TokenURL:     fmt.Sprintf("%s/oauth/token", apiURL),
-		Scopes:       scopes.ToStrings(scopeList),
+		Scopes:       scopes.ToStrings(config.Scopes),
 	}
 	return &ClientV1{
 		rootURL:                 strings.TrimSuffix(apiURL, "/"),

--- a/clientv1_test.go
+++ b/clientv1_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	"github.com/hexops/autogold/v2"
-	"github.com/hexops/valast"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 	"github.com/stretchr/testify/assert"
@@ -15,105 +13,16 @@ import (
 	"github.com/sourcegraph/sourcegraph-accounts-sdk-go/scopes"
 )
 
-type staticEnvGetter map[string]string
-
-func (e staticEnvGetter) Get(name, defaultValue, _ string) string {
-	v, ok := e[name]
-	if !ok {
-		return defaultValue
-	}
-	return v
-}
-
-func (e staticEnvGetter) GetOptional(name, description string) *string {
-	v := e.Get(name, "", description)
-	if v == "" {
-		return nil
-	}
-	return &v
-}
-
-func TestNewClientV1ConnectionConfigFromEnv(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		env  staticEnvGetter
-
-		want            autogold.Value
-		wantValidateErr autogold.Value
-	}{
-		{
-			name:            "no env",
-			env:             staticEnvGetter{},
-			want:            autogold.Expect(ClientV1ConnConfig{ExternalURL: "https://accounts.sourcegraph.com"}),
-			wantValidateErr: autogold.Expect("empty client ID"),
-		},
-		{
-			name: "only client credentials",
-			env: staticEnvGetter{
-				"SAMS_CLIENT_ID":     "fooclient",
-				"SAMS_CLIENT_SECRET": "barsecret",
-			},
-			want: autogold.Expect(ClientV1ConnConfig{
-				ExternalURL:  "https://accounts.sourcegraph.com",
-				ClientID:     "fooclient",
-				ClientSecret: "barsecret",
-			}),
-		},
-		{
-			name: "override API URL",
-			env: staticEnvGetter{
-				"SAMS_API_URL":       "https://my-internal-url.net",
-				"SAMS_CLIENT_ID":     "fooclient",
-				"SAMS_CLIENT_SECRET": "barsecret",
-			},
-			want: autogold.Expect(ClientV1ConnConfig{
-				ExternalURL:  "https://accounts.sourcegraph.com",
-				APIURL:       valast.Addr("https://my-internal-url.net").(*string),
-				ClientID:     "fooclient",
-				ClientSecret: "barsecret",
-			}),
-		},
-		{
-			name: "set all",
-			env: staticEnvGetter{
-				"SAMS_URL":           "https://my-external-url.net",
-				"SAMS_API_URL":       "https://my-internal-url.net",
-				"SAMS_CLIENT_ID":     "fooclient",
-				"SAMS_CLIENT_SECRET": "barsecret",
-			},
-			want: autogold.Expect(ClientV1ConnConfig{
-				ExternalURL:  "https://my-external-url.net",
-				APIURL:       valast.Addr("https://my-internal-url.net").(*string),
-				ClientID:     "fooclient",
-				ClientSecret: "barsecret",
-			}),
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			got := NewClientV1ConnectionConfigFromEnv(tc.env)
-			tc.want.Equal(t, got)
-
-			t.Run("Validate", func(t *testing.T) {
-				err := got.Validate()
-				if tc.wantValidateErr != nil {
-					require.Error(t, err)
-					tc.wantValidateErr.Equal(t, err.Error())
-				} else {
-					assert.NoError(t, err)
-				}
-			})
-		})
-	}
-}
-
 func TestNewClientV1(t *testing.T) {
 	c, err := NewClientV1(
-		ClientV1ConnConfig{
-			ExternalURL:  "https://accounts.sourcegraph.com",
+		ClientV1Config{
+			ConnConfig: ConnConfig{
+				ExternalURL: "https://accounts.sourcegraph.com",
+			},
 			ClientID:     "fooclient",
 			ClientSecret: "barsecret",
-		},
-		[]scopes.Scope{scopes.Profile})
+			Scopes:       []scopes.Scope{scopes.Profile},
+		})
 	require.NoError(t, err)
 	assert.NotEmpty(t, c.defaultInterceptors)
 }

--- a/sams.go
+++ b/sams.go
@@ -1,0 +1,59 @@
+package sams
+
+import "github.com/sourcegraph/sourcegraph/lib/errors"
+
+// envGetter is a helper interface for getting environment variables based on
+// the MSP runtime environment, matching the type
+// github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime/contract.Env.
+type envGetter interface {
+	// Get returns the value with the given name. If no value was supplied in the
+	// environment, the given default is used in its place. If no value is available,
+	// an error is added to the validation errors list.
+	Get(name, defaultValue, description string) string
+	// GetOptional returns the value with the given name, or nil if no value is
+	// available.
+	GetOptional(name, description string) *string
+}
+
+// ConnConfig is the basic configuration for connecting to a Sourcegraph Accounts
+// instance. Callers SHOULD use sams.NewConnConfigFromEnv(...) to construct this
+// where possible to ensure connection configuration is unified across SAMS clients
+// for ease of operation by Core Services team.
+type ConnConfig struct {
+	// ExternalURL is the configured default external ExternalURL of the relevant Sourcegraph
+	// Accounts instance.
+	ExternalURL string
+	// APIURL is the URL to use for Sourcegraph Accounts API interactions. This
+	// can be set to some internal URLs for private networking. If this is nil,
+	// the client will fall back to ExternalURL instead.
+	APIURL *string
+}
+
+const DefaultExternalURL = "https://accounts.sourcegraph.com"
+
+// NewConnConfigFromEnv initializes configuration for connecting to Sourcegraph
+// Accounts using default standards for loading environment variables. This
+// allows the Core Services team to more easily configure access.
+func NewConnConfigFromEnv(env envGetter) ConnConfig {
+	return ConnConfig{
+		ExternalURL: env.Get("SAMS_URL", DefaultExternalURL, "External URL of the connected SAMS instance"),
+		APIURL:      env.GetOptional("SAMS_API_URL", "URL to use for connecting to the API of a SAMS instance instead of SAMS_URL"),
+	}
+}
+
+func (c ConnConfig) Validate() error {
+	if c.ExternalURL == "" {
+		return errors.New("empty external URL")
+	}
+	if c.getAPIURL() == "" {
+		return errors.New("evaluated API URL is empty")
+	}
+	return nil
+}
+
+func (c ConnConfig) getAPIURL() string {
+	if c.APIURL != nil {
+		return *c.APIURL
+	}
+	return c.ExternalURL
+}

--- a/sams_test.go
+++ b/sams_test.go
@@ -1,0 +1,80 @@
+package sams
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/hexops/valast"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type staticEnvGetter map[string]string
+
+func (e staticEnvGetter) Get(name, defaultValue, _ string) string {
+	v, ok := e[name]
+	if !ok {
+		return defaultValue
+	}
+	return v
+}
+
+func (e staticEnvGetter) GetOptional(name, description string) *string {
+	v := e.Get(name, "", description)
+	if v == "" {
+		return nil
+	}
+	return &v
+}
+
+func TestNewClientV1ConnectionConfigFromEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  staticEnvGetter
+
+		want            autogold.Value
+		wantValidateErr autogold.Value
+	}{
+		{
+			name: "no env",
+			env:  staticEnvGetter{},
+			want: autogold.Expect(ConnConfig{ExternalURL: "https://accounts.sourcegraph.com"}),
+		},
+		{
+			name: "override API URL",
+			env: staticEnvGetter{
+				"SAMS_API_URL": "https://my-internal-url.net",
+			},
+			want: autogold.Expect(ConnConfig{
+				ExternalURL: "https://accounts.sourcegraph.com",
+				APIURL:      valast.Addr("https://my-internal-url.net").(*string),
+			}),
+		},
+		{
+			name: "set all",
+			env: staticEnvGetter{
+				"SAMS_URL":     "https://my-external-url.net",
+				"SAMS_API_URL": "https://my-internal-url.net",
+			},
+			want: autogold.Expect(ConnConfig{
+				ExternalURL: "https://my-external-url.net",
+				APIURL:      valast.Addr("https://my-internal-url.net").(*string),
+			}),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewConnConfigFromEnv(tc.env)
+			tc.want.Equal(t, got)
+
+			t.Run("Validate", func(t *testing.T) {
+				err := got.Validate()
+				if tc.wantValidateErr != nil {
+					require.Error(t, err)
+					tc.wantValidateErr.Equal(t, err.Error())
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
Unified connection config is important for Core Services to operate clients to e.g. set up private networking. #12 made an attempt at this, but with #13 I now realize that the first attempt was bad. This change:

1. Makes _only_ `ConnConfig` with SAMS URLs a unified env configuration. Nothing else really matters, so let's focus on this.
2. Unify root `sams` package to expose constructors for all client types. Each constructor gets a config struct that has a shared validation pattern, and embed the shared `sams.ConnConfig`
3. Remove per-client "env constructors" since realistically we don't care that much about those.

Lots of breaking changes, but we aren't stable-versioned yet, so... sorry 😅 I'll update `sg/sg` for this

## Test plan

CI