### PR TITLE
clientv1: fix ClientCredentialsTokenSource

### DIFF
--- a/clientv1.go
+++ b/clientv1.go
@@ -133,11 +133,11 @@ var (
 // source. Scopes should be defined using the available scopes package. All
 // requested scopes must be allowed by the registered client - see:
 // https://sourcegraph.notion.site/6cc4a1bd9cb247eea9674dbf9d5ce8c3
-func ClientCredentialsTokenSource(apiURL, clientID, clientSecret string, requestScopes []scopes.Scope) oauth2.TokenSource {
+func ClientCredentialsTokenSource(conn ConnConfig, clientID, clientSecret string, requestScopes []scopes.Scope) oauth2.TokenSource {
 	config := clientcredentials.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		TokenURL:     fmt.Sprintf("%s/oauth/token", apiURL),
+		TokenURL:     fmt.Sprintf("%s/oauth/token", conn.getAPIURL()),
 		Scopes:       scopes.ToStrings(requestScopes),
 	}
 	return config.TokenSource(context.Background())

--- a/clientv1_test.go
+++ b/clientv1_test.go
@@ -14,17 +14,16 @@ import (
 )
 
 func TestNewClientV1(t *testing.T) {
+	conn := ConnConfig{ExternalURL: "https://accounts.sourcegraph.com"}
 	config := ClientCredentialsTokenSource(
-		"https://accounts.sourcegraph.com",
+		conn,
 		"fooclient",
 		"barsecret",
 		[]scopes.Scope{scopes.Profile},
 	)
 	c, err := NewClientV1(
 		ClientV1Config{
-			ConnConfig: ConnConfig{
-				ExternalURL: "https://accounts.sourcegraph.com",
-			},
+			ConnConfig:  conn,
 			TokenSource: config,
 		})
 	require.NoError(t, err)


### PR DESCRIPTION
#16 makes it very hard to create `ClientCredentialsTokenSource` with the correct API URL, because `ConnConfig.getAPIURL()` is not exported, and it's also unclear what would be the correct API URL to use.

This change makes it so that `ClientCredentialsTokenSource` accepts `ConnConfig` like everywhere else, so that we can universally configure this stuff more easily (as is the goal)

## Test plan

CI