### PR TITLE
notifications/v1: start span, propagate context, improve logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/sourcegraph/log v0.0.0-20231018134238-fbadff7458bb
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20240315183013-b2b134e08ada
 	github.com/stretchr/testify v1.9.0
+	go.opentelemetry.io/otel v1.24.0
+	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/atomic v1.11.0
 	golang.org/x/oauth2 v0.19.0
 	google.golang.org/protobuf v1.34.0
@@ -68,9 +70,7 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.48.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.48.0 // indirect
-	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
-	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect

--- a/notifications/v1/types.go
+++ b/notifications/v1/types.go
@@ -1,5 +1,7 @@
 package v1
 
+import "go.opentelemetry.io/otel"
+
 // ⚠️ WARNING: These types MUST match the SAMS implementation, at
 // backend/internal/notification/types.go
 
@@ -14,3 +16,5 @@ type UserDeletedData struct {
 	// Email is the email address of the deleted user.
 	Email string `json:"email"`
 }
+
+var tracer = otel.Tracer("sams.notifications.v1")


### PR DESCRIPTION
Thought about this when looking at Joe's dogfood PR:

1. Propagate context provided to callback. Looking at the pub/sub client implementation, this context is important
2. Start a span when receiving messages - we do this with auto instrumentation in other parts of the SDK already.
3. Centralize all SDK logging for a received message with metadata for debugging

## Test plan

n/a