### PR TITLE
notificationsv1: update default name for better convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ func main() {
 }
 ```
 
-## Notifications API
+## Notifications API v1
 
 The SAMS Notifications API is for distributing notifications to downstream systems for them to take appropriate actions. For example, notifying systems that a user has been deleted.
 

--- a/notificationsv1.go
+++ b/notificationsv1.go
@@ -26,7 +26,7 @@ func NewNotificationsV1SubscriberConfigFromEnv(env envGetter) NotificationsV1Sub
 	defaultProject := env.Get("GOOGLE_CLOUD_PROJECT", "", "The GCP project that the service is running in")
 	return NotificationsV1SubscriberConfig{
 		ProjectID:      env.Get("SAMS_NOTIFICATION_PROJECT", defaultProject, "GCP project ID that the Pub/Sub subscription belongs to"),
-		SubscriptionID: env.Get("SAMS_NOTIFICATION_SUBSCRIPTION", "sams_notifications", "GCP Pub/Sub subscription ID to receive SAMS notifications from"),
+		SubscriptionID: env.Get("SAMS_NOTIFICATION_SUBSCRIPTION", "sams-notifications", "GCP Pub/Sub subscription ID to receive SAMS notifications from"),
 	}
 }
 


### PR DESCRIPTION
Some random googling and our use of subscription name seems to indicate `-` is preferred over `_`.

## Test plan

CI