### PR TITLE
chore: update lib/background and add golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,33 @@
+linters-settings:
+  nakedret:
+    max-func-lines: 0 # Disallow any unnamed return statement
+  depguard:
+    rules:
+      main:
+        deny:
+          - pkg: "errors"
+            desc: use "github.com/sourcegraph/sourcegraph/lib/errors" instead
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gosec
+
+linters:
+  enable:
+    - unused
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - nakedret
+    - gofmt
+    - rowserrcheck
+    - unconvert
+    - goimports
+    - unparam
+    - depguard
+    - gosec

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hexops/valast v1.4.4
 	github.com/lestrrat-go/jwx/v2 v2.0.21
 	github.com/sourcegraph/log v0.0.0-20231018134238-fbadff7458bb
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20240315183013-b2b134e08ada
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20240524140455-2589fef13ea8
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
+github.com/derision-test/go-mockgen/v2 v2.0.1 h1:2rzcJH6DT2jVfOt2spkmRJ8J6vQr9RQy3pXlQZ2pxNs=
+github.com/derision-test/go-mockgen/v2 v2.0.1/go.mod h1:1FvbovTCW7wmMxpBu2LtbhRgbX36MC5LLa6dw1GIhGc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -223,8 +225,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sourcegraph/log v0.0.0-20231018134238-fbadff7458bb h1:tHKdC+bXxxGJ0cy/R06kg6Z0zqwVGOWMx8uWsIwsaoY=
 github.com/sourcegraph/log v0.0.0-20231018134238-fbadff7458bb/go.mod h1:IDp09QkoqS8Z3CyN2RW6vXjgABkNpDbyjLIHNQwQ8P8=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20240315183013-b2b134e08ada h1:GSUoZOh723NncY2RBjmFu1EwpFfQjx4dGcMrDpfzxRU=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20240315183013-b2b134e08ada/go.mod h1:/Mu9Jw2BwXBzoZZQGGog01ALXloTolfIRO+blHjcOeU=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20240524140455-2589fef13ea8 h1:+eCHo5+HyLfTfkzuxiHZrQpOGTsTmoc9mT43XwTlrUQ=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20240524140455-2589fef13ea8/go.mod h1:ApmR9w5eQCJVbjxv/ij5XZkHJrSfHo2KiMqv94Zb7ec=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=


### PR DESCRIPTION
Update `lib/background` from the upstream https://github.com/sourcegraph/sourcegraph/pull/62136.

Also noticed that this repository is missing the golangci-lint config, thus added one.

## Test plan

CI