### PR TITLE
notifications: accept `Credentials` to passthrough

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/atomic v1.11.0
 	golang.org/x/oauth2 v0.19.0
+	google.golang.org/api v0.167.0
 	google.golang.org/protobuf v1.34.0
 )
 
@@ -81,7 +82,6 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.18.0 // indirect
-	google.golang.org/api v0.167.0 // indirect
 	google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240304161311-37d4d3c04a78 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240228224816-df926f6c8641 // indirect

--- a/notifications/v1/subscriber.go
+++ b/notifications/v1/subscriber.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/atomic"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )
 
@@ -41,9 +42,9 @@ type SubscriberOptions struct {
 	// Handlers is the collection of subscription handlers for each type of SAMS
 	// notifications.
 	Handlers SubscriberHandlers
-	// CredentialsFile is the path to the credentials file for the GCP Pub/Sub
-	// client. Empty value means to use the default credentials.
-	CredentialsFile string
+	// Credentials is the account credentials to be used for the GCP Pub/Sub client.
+	// Default credentials will be used when not set.
+	Credentials *google.Credentials
 }
 
 func (opts SubscriberOptions) Validate() error {
@@ -67,7 +68,7 @@ func NewSubscriber(logger log.Logger, opts SubscriberOptions) (background.Routin
 	}
 
 	logger = logger.Scoped("notification.subscriber")
-	client, err := pubsub.NewClient(context.Background(), opts.ProjectID, option.WithCredentialsFile(opts.CredentialsFile))
+	client, err := pubsub.NewClient(context.Background(), opts.ProjectID, option.WithCredentials(opts.Credentials))
 	if err != nil {
 		return nil, errors.Wrap(err, "create GCP Pub/Sub client")
 	}

--- a/notifications/v1/subscriber.go
+++ b/notifications/v1/subscriber.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/atomic"
+	"google.golang.org/api/option"
 )
 
 type subscriber struct {
@@ -40,6 +41,9 @@ type SubscriberOptions struct {
 	// Handlers is the collection of subscription handlers for each type of SAMS
 	// notifications.
 	Handlers SubscriberHandlers
+	// CredentialsFile is the path to the credentials file for the GCP Pub/Sub
+	// client. Empty value means to use the default credentials.
+	CredentialsFile string
 }
 
 func (opts SubscriberOptions) Validate() error {
@@ -63,7 +67,7 @@ func NewSubscriber(logger log.Logger, opts SubscriberOptions) (background.Routin
 	}
 
 	logger = logger.Scoped("notification.subscriber")
-	client, err := pubsub.NewClient(context.Background(), opts.ProjectID)
+	client, err := pubsub.NewClient(context.Background(), opts.ProjectID, option.WithCredentialsFile(opts.CredentialsFile))
 	if err != nil {
 		return nil, errors.Wrap(err, "create GCP Pub/Sub client")
 	}


### PR DESCRIPTION
Part of CORE-92

This is needed for cases (e.g. dotcom) where default credentials is not available.

## Test plan

CI