### PR TITLE
roles: add Roles

### DIFF
--- a/roles/roles.go
+++ b/roles/roles.go
@@ -36,16 +36,13 @@ func ToRoles(strings []string) []Role {
 
 var (
 	// services.Dotcom
-	dotcomRoles = []string{
-		RoleNameDotcomSiteAdmin,
-	}
-)
-
-const (
-	// Role names for services.Dotcom
 
 	// Dotcom site admin
-	RoleNameDotcomSiteAdmin = "site_admin"
+	RoleDotcomSiteAdmin = ToRole(services.Dotcom, "site_admin")
+
+	dotcomRoles = []Role{
+		RoleDotcomSiteAdmin,
+	}
 )
 
 // AllowedRoles is a concrete list of allowed roles that can be granted to a user.
@@ -56,13 +53,8 @@ type registeredRoles map[services.Service]AllowedRoles
 func registered() registeredRoles {
 	registered := make(registeredRoles)
 
-	appendRoles := func(service services.Service, roleNames []string) {
-		var roles AllowedRoles
-		for _, role := range roleNames {
-			roles = append(roles, ToRole(service, role))
-		}
+	appendRoles := func(service services.Service, roles []Role) {
 		registered[service] = roles
-
 	}
 
 	appendRoles(services.Dotcom, dotcomRoles)

--- a/roles/roles.go
+++ b/roles/roles.go
@@ -10,7 +10,7 @@ import (
 type Role string
 
 // ToRole returns a role string in the format of
-// "service::role".
+// "service::role", which comprises a fully qualified role name.
 func ToRole(service services.Service, name string) Role {
 	return Role(string(service) + "::" + name)
 }

--- a/roles/roles.go
+++ b/roles/roles.go
@@ -25,6 +25,7 @@ func ToStrings(roles []Role) []string {
 }
 
 // ToRoles converts a list of strings to a list of roles.
+// It does not validate each input value.
 func ToRoles(strings []string) []Role {
 	roles := make([]Role, len(strings))
 	for i, s := range strings {

--- a/roles/roles.go
+++ b/roles/roles.go
@@ -1,0 +1,58 @@
+package roles
+
+import (
+	"slices"
+
+	"github.com/sourcegraph/sourcegraph-accounts-sdk-go/services"
+)
+
+// Role is the string literal of a role.
+type Role string
+
+// RoleRegistration is a struct that contains the display name and roles for a service.
+type RoleRegistration struct {
+	DisplayName string
+	Roles       []Role
+}
+
+var (
+	// services.Dotcom
+	dotcomDisplayName string = "Sourcegraph Dotcom"
+	dotcomRoles              = []Role{
+		RoleDotcomSiteadmin,
+	}
+)
+
+const (
+	// Roles for services.Dotcom
+
+	// RoleDotcomSiteadmin is the role for site admins on dotcom
+	RoleDotcomSiteadmin Role = "site_admin"
+)
+
+// Registered returns a map of all registered roles for all services.
+type RegisteredRoles map[services.Service]RoleRegistration
+
+func Registered() RegisteredRoles {
+	registered := map[services.Service]RoleRegistration{}
+
+	appendRoles := func(service services.Service, registration RoleRegistration) {
+		registered[service] = registration
+	}
+
+	appendRoles(services.Dotcom, RoleRegistration{
+		DisplayName: dotcomDisplayName,
+		Roles:       dotcomRoles,
+	})
+	// 👉 ADD YOUR ROLES HERE
+
+	return registered
+}
+
+func (r RegisteredRoles) Contains(service services.Service, role Role) bool {
+	registration, ok := r[service]
+	if !ok {
+		return false
+	}
+	return slices.Contains(registration.Roles, role)
+}

--- a/roles/roles.go
+++ b/roles/roles.go
@@ -35,9 +35,16 @@ func ToRoles(strings []string) []Role {
 	return roles
 }
 
+// ParsedRole is a role parsed into its service and name.
 type ParsedRole struct {
 	Service services.Service
 	Name    string
+}
+
+// ToRole creates a fully qualified role from a parsed role
+// in the format of service::name.
+func (p ParsedRole) ToRole() Role {
+	return ToRole(p.Service, p.Name)
 }
 
 // Parse parses a role into its parts. It returns the service, and the role name.

--- a/roles/roles_test.go
+++ b/roles/roles_test.go
@@ -44,10 +44,25 @@ func TestAllowedContains(t *testing.T) {
 	}
 }
 
-func TestAllowedEntitleGoldenList(t *testing.T) {
-	autogold.Expect(EntitleRoles{
-		services.Service("dotcom"): AllowedRoles{
-			Role("dotcom::site_admin"),
+func TestAllowedRolesByService(t *testing.T) {
+	tests := []struct {
+		name     string
+		service  services.Service
+		expected autogold.Value
+	}{
+		{
+			name:    "dotcom",
+			service: services.Dotcom,
+			expected: autogold.Expect([]Role{
+				Role("dotcom::site_admin"),
+			}),
 		},
-	}).Equal(t, AllowedEntitle())
+	}
+	allowed := Allowed()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := allowed.ByService()
+			test.expected.Equal(t, got[test.service])
+		})
+	}
 }

--- a/roles/roles_test.go
+++ b/roles/roles_test.go
@@ -25,7 +25,7 @@ func TestAllowedContains(t *testing.T) {
 		},
 		{
 			name:     "dotcom site admin",
-			role:     ToRole(services.Dotcom, RoleNameDotcomSiteAdmin),
+			role:     RoleDotcomSiteAdmin,
 			expected: true,
 		},
 		{

--- a/roles/roles_test.go
+++ b/roles/roles_test.go
@@ -1,0 +1,47 @@
+package roles
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/sourcegraph/sourcegraph-accounts-sdk-go/services"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisteredGoldenList(t *testing.T) {
+	autogold.Expect(RegisteredRoles{
+		services.Service("dotcom"): RoleRegistration{
+			DisplayName: "Sourcegraph Dotcom",
+			Roles:       []Role{Role("site_admin")},
+		}}).Equal(t, Registered())
+}
+
+func TestRegisteredContains(t *testing.T) {
+	tests := []struct {
+		name     string
+		service  services.Service
+		role     Role
+		expected bool
+	}{
+		{
+			name:     "dotcom site admin",
+			service:  services.Dotcom,
+			role:     RoleDotcomSiteadmin,
+			expected: true,
+		},
+		{
+			name:     "dotcom site admin",
+			service:  services.Dotcom,
+			role:     Role("not_a_role"),
+			expected: false,
+		},
+	}
+
+	registered := Registered()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := registered.Contains(test.service, test.role)
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}

--- a/roles/roles_test.go
+++ b/roles/roles_test.go
@@ -8,40 +8,46 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRegisteredGoldenList(t *testing.T) {
-	autogold.Expect(RegisteredRoles{
-		services.Service("dotcom"): RoleRegistration{
-			DisplayName: "Sourcegraph Dotcom",
-			Roles:       []Role{Role("site_admin")},
-		}}).Equal(t, Registered())
+func TestAllowedGoldenList(t *testing.T) {
+	autogold.Expect(AllowedRoles{Role("dotcom::site_admin")}).Equal(t, Allowed())
 }
 
-func TestRegisteredContains(t *testing.T) {
+func TestAllowedContains(t *testing.T) {
 	tests := []struct {
 		name     string
-		service  services.Service
 		role     Role
 		expected bool
 	}{
 		{
-			name:     "dotcom site admin",
-			service:  services.Dotcom,
-			role:     RoleDotcomSiteadmin,
+			name:     "dotcom site admin literal",
+			role:     "dotcom::site_admin",
 			expected: true,
 		},
 		{
 			name:     "dotcom site admin",
-			service:  services.Dotcom,
-			role:     Role("not_a_role"),
+			role:     ToRole(services.Dotcom, RoleNameDotcomSiteAdmin),
+			expected: true,
+		},
+		{
+			name:     "dotcom not a role",
+			role:     "dotcom::not_a_role",
 			expected: false,
 		},
 	}
 
-	registered := Registered()
+	allowed := Allowed()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := registered.Contains(test.service, test.role)
+			got := allowed.Contains(test.role)
 			assert.Equal(t, test.expected, got)
 		})
 	}
+}
+
+func TestAllowedEntitleGoldenList(t *testing.T) {
+	autogold.Expect(EntitleRoles{
+		services.Service("dotcom"): AllowedRoles{
+			Role("dotcom::site_admin"),
+		},
+	}).Equal(t, AllowedEntitle())
 }

--- a/services/services.go
+++ b/services/services.go
@@ -1,0 +1,13 @@
+package services
+
+// Service is a type for the service part of a scope and/or role.
+type Service string
+
+// The list of registered services that publish scopes and/or roles.
+const (
+	CodyGateway      Service = "cody_gateway"
+	Dotcom           Service = "dotcom"
+	SAMS             Service = "sams"
+	TelemetryGateway Service = "telemetry_gateway"
+	EnterprisePortal Service = "enterprise_portal"
+)

--- a/services/services.go
+++ b/services/services.go
@@ -11,3 +11,18 @@ const (
 	TelemetryGateway Service = "telemetry_gateway"
 	EnterprisePortal Service = "enterprise_portal"
 )
+
+var serviceNames = map[Service]string{
+	CodyGateway:      "Cody Gateway",
+	Dotcom:           "Sourcegraph Dotcom",
+	SAMS:             "Sourcegraph Accounts Management System",
+	TelemetryGateway: "Telemetry Gateway",
+	EnterprisePortal: "Enterprise Portal",
+}
+
+func (s Service) DisplayName() string {
+	if v, ok := serviceNames[s]; ok {
+		return v
+	}
+	return string(s)
+}


### PR DESCRIPTION
Adds Roles support to the SDK.
Moves Services into a separate package so that it can be imported by both Roles and Scopes.

Closes CORE-204
## Test plan
CI