### PR TITLE
add missing workspaces scope

### DIFF
--- a/scopes/scopes.go
+++ b/scopes/scopes.go
@@ -105,6 +105,7 @@ var (
 	workspacesPermissions = []Permission{
 		"workspace",
 		"instance",
+		"permission.workspace",
 	}
 )
 

--- a/scopes/scopes_test.go
+++ b/scopes/scopes_test.go
@@ -56,6 +56,9 @@ func TestAllowedGoldenList(t *testing.T) {
 		Scope("workspaces::instance::read"),
 		Scope("workspaces::instance::write"),
 		Scope("workspaces::instance::delete"),
+		Scope("workspaces::permission.workspace::read"),
+		Scope("workspaces::permission.workspace::write"),
+		Scope("workspaces::permission.workspace::delete"),
 	}).Equal(t, Allowed())
 }
 


### PR DESCRIPTION
it's used by clients but not defined here https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/workspaces/client.go?L37%3A1-43%3A3

```
sg sams client create --sams-server='https://accounts.sgdev.org/' --redirect-uris='https://default.sourcegraphev.app/.auth/callback' -s "workspaces::workspace::read" -s "workspaces::workspace::write" -s "workspaces::instance::read" -s "workspaces::instance::write" -s "workspaces::permission.workspace::read" src-da523f8af62d27a0519b
```

```
{"error":"scope workspaces::instance::read is not one of allowed scopes: [openid profile email offline_access client.ssc client.dotcom cody_gateway::flaggedprompts::read cody_gateway::flaggedprompts::write cody_gateway::flaggedprompts::delete sams::user::read sams::user::write sams::user::delete sams::user.profile::read sams::user.profile::write sams::user.profile::delete sams::user.roles::read sams::user.roles::write sams::user.roles::delete sams::user.metadata::read sams::user.metadata::write sams::user.metadata::delete sams::user.metadata.cody::read sams::user.metadata.cody::write sams::user.metadata.cody::delete sams::user.metadata.dotcom::read sams::user.metadata.dotcom::write sams::user.metadata.dotcom::delete sams::session::read sams::session::write sams::session::delete telemetry_gateway::events::read telemetry_gateway::events::write telemetry_gateway::events::delete enterprise_portal::subscription::read enterprise_portal::subscription::write enterprise_portal::subscription::delete enterprise_portal::permission.subscription::read enterprise_portal::permission.subscription::write enterprise_portal::permission.subscription::delete enterprise_portal::codyaccess::read enterprise_portal::codyaccess::write enterprise_portal::codyaccess::delete workspaces::workspace::read workspaces::workspace::write workspaces::workspace::delete]"}
```

hence throwing

## Test plan


CI