### PR TITLE
roles: refactor to support Resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.28.0
 	go.uber.org/atomic v1.11.0
 	golang.org/x/oauth2 v0.21.0
+	golang.org/x/text v0.16.0
 	google.golang.org/api v0.190.0
 	google.golang.org/protobuf v1.34.2
 )
@@ -79,7 +80,6 @@ require (
 	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
-	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	google.golang.org/genproto v0.0.0-20240730163845-b1a4ccb954bf // indirect

--- a/roles/roles.go
+++ b/roles/roles.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph-accounts-sdk-go/services"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Role is always the full qualified role name, e.g. "dotcom::site_admin".
@@ -47,13 +49,19 @@ const (
 	// Service type is a special type used for service level roles.
 	Service ResourceType = "service"
 	// Subscription resources for Enterprise Portal.
-	Subscription ResourceType = "subscription"
+	EnterpriseSubscription ResourceType = "enterprise_subscription"
 )
 
 // IsService returns true if the resource type is a service.
 // This is a special helper function as service level roles have special handling.
 func (r ResourceType) IsService() bool {
 	return r == Service
+}
+
+// Display returns the display name of the resource type.
+func (r ResourceType) Display() string {
+	s := strings.ReplaceAll(string(r), "_", " ")
+	return cases.Title(language.English).String(s)
 }
 
 // roleInfo is the sdk internal representation of a role.
@@ -103,7 +111,7 @@ var (
 		{
 			id:           RoleEnterprisePortalCustomerAdmin,
 			service:      services.EnterprisePortal,
-			resourceType: Subscription,
+			resourceType: EnterpriseSubscription,
 		},
 	}
 )

--- a/roles/roles_test.go
+++ b/roles/roles_test.go
@@ -89,8 +89,8 @@ func TestRolesByResourceType(t *testing.T) {
 			}),
 		},
 		{
-			name:     "subscription",
-			resource: Subscription,
+			name:     "enterprise_subscription",
+			resource: EnterpriseSubscription,
 			expected: autogold.Expect([]Role{
 				Role("enterprise_portal::customer_admin"),
 			}),
@@ -120,6 +120,31 @@ func TestToService(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.role.Service()
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestDisplay(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource ResourceType
+		want     string
+	}{
+		{
+			name:     "service",
+			resource: Service,
+			want:     "Service",
+		},
+		{
+			name:     "enterprise_subscription",
+			resource: EnterpriseSubscription,
+			want:     "Enterprise Subscription",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.resource.Display()
 			assert.Equal(t, test.want, got)
 		})
 	}

--- a/roles/roles_test.go
+++ b/roles/roles_test.go
@@ -1,6 +1,7 @@
 package roles
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/hexops/autogold/v2"
@@ -8,11 +9,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAllowedGoldenList(t *testing.T) {
-	autogold.Expect(AllowedRoles{Role("dotcom::site_admin"), Role("ssc::admin")}).Equal(t, Allowed())
+func TestGoldenList(t *testing.T) {
+	got := List()
+	slices.Sort(got)
+	autogold.Expect([]Role{
+		Role("dotcom::site_admin"),
+		Role("enterprise_portal::customer_admin"),
+		Role("ssc::admin"),
+	}).Equal(t, got)
 }
 
-func TestAllowedContains(t *testing.T) {
+func TestContains(t *testing.T) {
 	tests := []struct {
 		name     string
 		role     Role
@@ -35,16 +42,15 @@ func TestAllowedContains(t *testing.T) {
 		},
 	}
 
-	allowed := Allowed()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := allowed.Contains(test.role)
+			got := Contains(test.role)
 			assert.Equal(t, test.expected, got)
 		})
 	}
 }
 
-func TestAllowedRolesByService(t *testing.T) {
+func TestRolesByService(t *testing.T) {
 	tests := []struct {
 		name     string
 		service  services.Service
@@ -58,11 +64,63 @@ func TestAllowedRolesByService(t *testing.T) {
 			}),
 		},
 	}
-	allowed := Allowed()
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := allowed.ByService()
-			test.expected.Equal(t, got[test.service])
+			got := ByService()[test.service]
+			slices.Sort(got)
+			test.expected.Equal(t, got)
+		})
+	}
+}
+
+func TestRolesByResourceType(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource ResourceType
+		expected autogold.Value
+	}{
+		{
+			name:     "service",
+			resource: Service,
+			expected: autogold.Expect([]Role{
+				Role("dotcom::site_admin"),
+				Role("ssc::admin"),
+			}),
+		},
+		{
+			name:     "subscription",
+			resource: Subscription,
+			expected: autogold.Expect([]Role{
+				Role("enterprise_portal::customer_admin"),
+			}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := ByResourceType()[test.resource]
+			slices.Sort(got)
+			test.expected.Equal(t, got)
+		})
+	}
+}
+
+func TestToService(t *testing.T) {
+	tests := []struct {
+		name string
+		role Role
+		want services.Service
+	}{
+		{
+			name: "dotcom site admin",
+			role: RoleDotcomSiteAdmin,
+			want: services.Dotcom,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.role.Service()
+			assert.Equal(t, test.want, got)
 		})
 	}
 }


### PR DESCRIPTION
To support roles at the resource level this refactors the sdk internals with a new `roleInfo` type. From which the data can be transformed by helper methods to be used by SAMS + integrations.

Previously roles were registered + exposed from the `AllowedRoles` function.
Registration has been split into an internal variable `registeredRoles` from which public functions such as `List`, `ByService`, `ByResourceType`, etc. derive different views of the data.
## Test plan
CI