### PR TITLE
roles: add helper to get all service roles grouped by service

### DIFF
--- a/roles/roles.go
+++ b/roles/roles.go
@@ -162,3 +162,14 @@ func ByResourceType() map[ResourceType][]Role {
 	}
 	return byResourceType
 }
+
+// ServiceRolesByService returns all allowed service roles grouped by service.
+func ServiceRolesByService() map[services.Service][]Role {
+	byService := make(map[services.Service][]Role)
+	for _, role := range registeredRoles {
+		if role.resourceType.IsService() {
+			byService[role.service] = append(byService[role.service], role.id)
+		}
+	}
+	return byService
+}

--- a/roles/roles_test.go
+++ b/roles/roles_test.go
@@ -105,6 +105,36 @@ func TestRolesByResourceType(t *testing.T) {
 	}
 }
 
+func TestServiceRolesByService(t *testing.T) {
+	tests := []struct {
+		name     string
+		service  services.Service
+		expected autogold.Value
+	}{
+		{
+			name:    "dotcom",
+			service: services.Dotcom,
+			expected: autogold.Expect([]Role{
+				Role("dotcom::site_admin"),
+			}),
+		},
+		{
+			name:    "ssc",
+			service: services.SSC,
+			expected: autogold.Expect([]Role{
+				Role("ssc::admin"),
+			}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := ServiceRolesByService()[test.service]
+			slices.Sort(got)
+			test.expected.Equal(t, got)
+		})
+	}
+}
+
 func TestToService(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
While updating SAMS' Entitle integration to support Service Roles + Resource Roles it became clear that a helper in the sdk to iterate over service roles grouped by service would be useful to have.
This PR adds this new helper function.

## Test plan
CI