### PR TITLE
feat/client: add opt-in caching on sessions, token introspection

### DIFF
--- a/clientv1_sessions.go
+++ b/clientv1_sessions.go
@@ -6,6 +6,7 @@ import (
 	"connectrpc.com/connect"
 	"golang.org/x/oauth2"
 
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	clientsv1 "github.com/sourcegraph/sourcegraph-accounts-sdk-go/clients/v1"
 	"github.com/sourcegraph/sourcegraph-accounts-sdk-go/clients/v1/clientsv1connect"
 )
@@ -14,6 +15,8 @@ import (
 // SessionsService API v1.
 type SessionsServiceV1 struct {
 	client *ClientV1
+	// sessionsCache may be nil if not enabled.
+	sessionsCache *expirable.LRU[string, *clientsv1.Session]
 }
 
 func (s *SessionsServiceV1) newClient(ctx context.Context) clientsv1connect.SessionsServiceClient {
@@ -30,11 +33,20 @@ func (s *SessionsServiceV1) newClient(ctx context.Context) clientsv1connect.Sess
 //
 // Required scope: sams::session::read
 func (s *SessionsServiceV1) GetSessionByID(ctx context.Context, id string) (*clientsv1.Session, error) {
+	if s.sessionsCache != nil {
+		if cached, ok := s.sessionsCache.Get(id); ok {
+			return cached, nil
+		}
+	}
+
 	req := &clientsv1.GetSessionRequest{Id: id}
 	client := s.newClient(ctx)
 	resp, err := parseResponseAndError(client.GetSession(ctx, connect.NewRequest(req)))
 	if err != nil {
 		return nil, err
+	}
+	if s.sessionsCache != nil {
+		_ = s.sessionsCache.Add(id, resp.Msg.Session)
 	}
 	return resp.Msg.Session, nil
 }
@@ -52,5 +64,8 @@ func (s *SessionsServiceV1) SignOutSession(ctx context.Context, sessionID, userI
 	}
 	client := s.newClient(ctx)
 	_, err := parseResponseAndError(client.SignOutSession(ctx, connect.NewRequest(req)))
+	if err == nil && s.sessionsCache != nil {
+		_ = s.sessionsCache.Remove(sessionID)
+	}
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.11.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hexops/autogold/v2 v2.2.1
 	github.com/hexops/valast v1.4.4
 	github.com/lestrrat-go/jwx/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.13.0 h1:yitjD5f7jQHhyDsnhKEBU52NdvvdSeGzlAnDPT0hH1s=
 github.com/googleapis/gax-go/v2 v2.13.0/go.mod h1:Z/fvTZXF8/uw7Xu5GuslPw+bplx6SS338j1Is2S+B7A=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hexops/autogold v0.8.1/go.mod h1:97HLDXyG23akzAoRYJh/2OBs3kd80eHyKPvZw0S5ZBY=
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=
 github.com/hexops/autogold v1.3.1/go.mod h1:sQO+mQUCVfxOKPht+ipDSkJ2SCJ7BNJVHZexsXqWMx4=


### PR DESCRIPTION
Adds opt-in caching for high-volume API checks:

1. session lookup (Workspaces in particular)
2. token introspection (pretty much all SAMS M2M users)

The volume of token introspection in particular causes checks to be quite flakey for some services. Instead of having to set up private networking for everything (at least until we have https://linear.app/sourcegraph/issue/CORE-110 as a longer-term and more flexible solution), let's allow us to opt-in to local in-memory caching as a band-aid and see if that helps.

## Test plan

CI