### PR TITLE
scopes: allow read permission on 'user.metadata.internal'

### DIFF
--- a/scopes/scopes.go
+++ b/scopes/scopes.go
@@ -92,6 +92,8 @@ var (
 
 		// Grants access to all scopes - use sparingly.
 		"user.metadata",
+		// Read-only SAMS-internal metadata
+		"user.metadata.internal",
 		// Cody Pro and SSC metadata
 		"user.metadata.cody",
 		// Legacy Sourcegraph.com metadata
@@ -155,6 +157,11 @@ func Allowed() AllowedScopes {
 	// Add full { read, write, delete } actions for all permissions for the given service.
 	appendScopes := func(service services.Service, permissions []Permission) {
 		for _, permission := range permissions {
+			// Special case: read-only for SAMS-internal user metadata.
+			if permission == "user.metadata.internal" {
+				allowed = append(allowed, ToScope(service, permission, ActionRead))
+				continue
+			}
 			allowed = append(
 				allowed,
 				[]Scope{

--- a/scopes/scopes_test.go
+++ b/scopes/scopes_test.go
@@ -32,6 +32,7 @@ func TestAllowedGoldenList(t *testing.T) {
 		Scope("sams::user.metadata::read"),
 		Scope("sams::user.metadata::write"),
 		Scope("sams::user.metadata::delete"),
+		Scope("sams::user.metadata.internal::read"),
 		Scope("sams::user.metadata.cody::read"),
 		Scope("sams::user.metadata.cody::write"),
 		Scope("sams::user.metadata.cody::delete"),


### PR DESCRIPTION
This allows services to access whether a SAMS user is a teammate or not (`internal: { employee }`), as assigned by the SAMS `employeesync` job

https://sourcegraph.slack.com/archives/C079SAU0E72/p1736287834708009?thread_ts=1736212496.250319&cid=C079SAU0E72

## Test plan

CI