### PR TITLE
roles: add service-level Workspaces service admin role

### DIFF
--- a/roles/roles.go
+++ b/roles/roles.go
@@ -128,6 +128,18 @@ var (
 	}
 )
 
+// services.Workspaces
+var (
+	RoleWorkspacesServiceAdmin = ToRole(services.Workspaces, "service_admin")
+	workspacesRoles            = []roleInfo{
+		{
+			id:           RoleWorkspacesServiceAdmin,
+			service:      services.Workspaces,
+			resourceType: Service,
+		},
+	}
+)
+
 var registeredRoles = func() []roleInfo {
 	var registered []roleInfo
 
@@ -138,6 +150,7 @@ var registeredRoles = func() []roleInfo {
 	appendRoles(dotcomRoles)
 	appendRoles(sscRoles)
 	appendRoles(enterprisePortalRoles)
+	appendRoles(workspacesRoles)
 	// 👉 ADD YOUR ROLES HERE
 
 	return registered

--- a/roles/roles_test.go
+++ b/roles/roles_test.go
@@ -13,9 +13,9 @@ func TestGoldenList(t *testing.T) {
 	got := List()
 	slices.Sort(got)
 	autogold.Expect([]Role{
-		Role("dotcom::site_admin"),
-		Role("enterprise_portal::customer_admin"),
+		Role("dotcom::site_admin"), Role("enterprise_portal::customer_admin"),
 		Role("ssc::admin"),
+		Role("workspaces::service_admin"),
 	}).Equal(t, got)
 }
 
@@ -84,8 +84,8 @@ func TestRolesByResourceType(t *testing.T) {
 			name:     "service",
 			resource: Service,
 			expected: autogold.Expect([]Role{
-				Role("dotcom::site_admin"),
-				Role("ssc::admin"),
+				Role("dotcom::site_admin"), Role("ssc::admin"),
+				Role("workspaces::service_admin"),
 			}),
 		},
 		{


### PR DESCRIPTION
Part of https://linear.app/sourcegraph/issue/CORE-363/workspaces-internal-trigger-to-suspendun-suspend-a-workspace - this will be used to gate access to the upcoming `AdminstrationService` for administering workspaces.

## Test plan

CI