### PR TITLE
sdk: allow customised base HTTP transport

### DIFF
--- a/accountsv1.go
+++ b/accountsv1.go
@@ -1,6 +1,8 @@
 package sams
 
 import (
+	"net/http"
+
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"golang.org/x/oauth2"
 
@@ -17,6 +19,9 @@ type AccountsV1Config struct {
 	// as needed. But if you only have the access token, you will need to use a
 	// StaticTokenSource instead.
 	TokenSource oauth2.TokenSource
+	// BaseTransport is the base transport to use for HTTP requests. If not
+	// provided, http.DefaultTransport will be used.
+	BaseTransport http.RoundTripper
 }
 
 func (c AccountsV1Config) Validate() error {
@@ -34,5 +39,5 @@ func NewAccountsV1(config AccountsV1Config) (*accountsv1.Client, error) {
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
-	return accountsv1.NewClient(config.getAPIURL(), config.TokenSource), nil
+	return accountsv1.NewClient(config.getAPIURL(), config.TokenSource, config.BaseTransport), nil
 }

--- a/clientv1_roles.go
+++ b/clientv1_roles.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 
 	"connectrpc.com/connect"
-	"golang.org/x/oauth2"
 
 	"github.com/google/uuid"
 	clientsv1 "github.com/sourcegraph/sourcegraph-accounts-sdk-go/clients/v1"
@@ -21,9 +20,9 @@ type RolesServiceV1 struct {
 	client *ClientV1
 }
 
-func (s *RolesServiceV1) newClient(ctx context.Context) clientsv1connect.RolesServiceClient {
+func (s *RolesServiceV1) newClient() clientsv1connect.RolesServiceClient {
 	return clientsv1connect.NewRolesServiceClient(
-		oauth2.NewClient(ctx, s.client.tokenSource),
+		s.client.httpClient(),
 		s.client.gRPCURL(),
 		connect.WithInterceptors(s.client.defaultInterceptors...),
 	)
@@ -61,7 +60,7 @@ func (s *RolesServiceV1) RegisterRoleResources(ctx context.Context, metadata Reg
 		return 0, errors.Wrap(err, "failed to generate revision for request metadata")
 	}
 
-	client := s.newClient(ctx)
+	client := s.newClient()
 	stream := client.RegisterRoleResources(ctx)
 	// Metadata must be submitted first in the stream.
 	err = stream.Send(&clientsv1.RegisterRoleResourcesRequest{

--- a/clientv1_tokens.go
+++ b/clientv1_tokens.go
@@ -7,7 +7,6 @@ import (
 	"connectrpc.com/connect"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/oauth2"
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	clientsv1 "github.com/sourcegraph/sourcegraph-accounts-sdk-go/clients/v1"
@@ -25,7 +24,7 @@ type TokensServiceV1 struct {
 
 func (s *TokensServiceV1) newClient(ctx context.Context) clientsv1connect.TokensServiceClient {
 	return clientsv1connect.NewTokensServiceClient(
-		oauth2.NewClient(ctx, s.client.tokenSource),
+		s.client.httpClient(),
 		s.client.gRPCURL(),
 		connect.WithInterceptors(s.client.defaultInterceptors...),
 	)

--- a/clientv1_users.go
+++ b/clientv1_users.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	"golang.org/x/oauth2"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	clientsv1 "github.com/sourcegraph/sourcegraph-accounts-sdk-go/clients/v1"
@@ -18,9 +17,9 @@ type UsersServiceV1 struct {
 	client *ClientV1
 }
 
-func (s *UsersServiceV1) newClient(ctx context.Context) clientsv1connect.UsersServiceClient {
+func (s *UsersServiceV1) newClient() clientsv1connect.UsersServiceClient {
 	return clientsv1connect.NewUsersServiceClient(
-		oauth2.NewClient(ctx, s.client.tokenSource),
+		s.client.httpClient(),
 		s.client.gRPCURL(),
 		connect.WithInterceptors(s.client.defaultInterceptors...),
 	)
@@ -32,7 +31,7 @@ func (s *UsersServiceV1) newClient(ctx context.Context) clientsv1connect.UsersSe
 // Required scope: profile
 func (s *UsersServiceV1) GetUserByID(ctx context.Context, id string) (*clientsv1.User, error) {
 	req := &clientsv1.GetUserRequest{Id: id}
-	client := s.newClient(ctx)
+	client := s.newClient()
 	resp, err := parseResponseAndError(client.GetUser(ctx, connect.NewRequest(req)))
 	if err != nil {
 		return nil, err
@@ -46,7 +45,7 @@ func (s *UsersServiceV1) GetUserByID(ctx context.Context, id string) (*clientsv1
 // Required scope: profile
 func (s *UsersServiceV1) GetUserByEmail(ctx context.Context, email string) (*clientsv1.User, error) {
 	req := &clientsv1.GetUserRequest{Email: email}
-	client := s.newClient(ctx)
+	client := s.newClient()
 	resp, err := parseResponseAndError(client.GetUser(ctx, connect.NewRequest(req)))
 	if err != nil {
 		return nil, err
@@ -62,7 +61,7 @@ func (s *UsersServiceV1) GetUserByEmail(ctx context.Context, email string) (*cli
 // Required scopes: profile
 func (s *UsersServiceV1) GetUsersByIDs(ctx context.Context, ids []string) ([]*clientsv1.User, error) {
 	req := &clientsv1.GetUsersRequest{Ids: ids}
-	client := s.newClient(ctx)
+	client := s.newClient()
 	resp, err := parseResponseAndError(client.GetUsers(ctx, connect.NewRequest(req)))
 	if err != nil {
 		return nil, err
@@ -79,7 +78,7 @@ func (s *UsersServiceV1) GetUserRolesByID(ctx context.Context, userID, service s
 		Id:      userID,
 		Service: service,
 	}
-	client := s.newClient(ctx)
+	client := s.newClient()
 	resp, err := parseResponseAndError(client.GetUserRoles(ctx, connect.NewRequest(req)))
 	if err != nil {
 		return nil, err
@@ -104,7 +103,7 @@ func (s *UsersServiceV1) GetUserMetadata(ctx context.Context, userID string, nam
 		Id:         userID,
 		Namespaces: namespaces,
 	}
-	client := s.newClient(ctx)
+	client := s.newClient()
 	resp, err := parseResponseAndError(client.GetUserMetadata(ctx, connect.NewRequest(req)))
 	if err != nil {
 		return nil, err
@@ -133,7 +132,7 @@ func (s *UsersServiceV1) UpdateUserMetadata(ctx context.Context, userID, namespa
 			Metadata:  md,
 		},
 	}
-	client := s.newClient(ctx)
+	client := s.newClient()
 	resp, err := parseResponseAndError(client.UpdateUserMetadata(ctx, connect.NewRequest(req)))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
INC-383 - we may want to allow clients to set special headers to bypass CF rules, where private networking is not available.

Part of https://linear.app/sourcegraph/issue/CORE-755/dotcom-include-special-magic-header-when-talking-to-sams

## Test plan

CI