### PR TITLE
chore: add workspace metering scopes

### DIFF
--- a/scopes/scopes.go
+++ b/scopes/scopes.go
@@ -124,6 +124,7 @@ var (
 		"workspace",
 		"instance",
 		"permission.workspace",
+		"metering",
 	}
 	mailGatekeeperPermissions = []Permission{
 		"emails",

--- a/scopes/scopes_test.go
+++ b/scopes/scopes_test.go
@@ -90,6 +90,8 @@ func TestAllowedGoldenList(t *testing.T) {
 		Scope("workspaces::permission.workspace::read"),
 		Scope("workspaces::permission.workspace::write"),
 		Scope("workspaces::permission.workspace::delete"),
+		Scope("workspaces::metering::read"),
+		Scope("workspaces::metering::write"),
 		Scope("analytics::analytics::read"),
 		Scope("analytics::analytics::write"),
 		Scope("analytics::analytics::delete"),

--- a/scopes/scopes_test.go
+++ b/scopes/scopes_test.go
@@ -92,6 +92,7 @@ func TestAllowedGoldenList(t *testing.T) {
 		Scope("workspaces::permission.workspace::delete"),
 		Scope("workspaces::metering::read"),
 		Scope("workspaces::metering::write"),
+		Scope("workspaces::metering::delete"),
 		Scope("analytics::analytics::read"),
 		Scope("analytics::analytics::write"),
 		Scope("analytics::analytics::delete"),


### PR DESCRIPTION
Adds workspace metering scopes as part of [Core Services Deep Search metering, billing, and support](https://linear.app/sourcegraph/project/core-services-deep-search-metering-billing-and-support-34c68451d332) project


## Test plan
CI