### PR TITLE
Disallow SAT in clientcredentials middleware

### DIFF
--- a/auth/clientcredentials/connectrpc.go
+++ b/auth/clientcredentials/connectrpc.go
@@ -129,6 +129,10 @@ func (i *Interceptor) requireScope(ctx context.Context, headers http.Header, req
 	if err != nil {
 		return nil, connectInternalError(ctx, i.logger, err, "unable to validate token")
 	}
+	if result.UserID != "" {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("SAT token not allowed"))
+	}
+
 	span.SetAttributes(
 		attribute.String("client_id", result.ClientID),
 		attribute.String("token_expires_at", result.ExpiresAt.String()),

--- a/auth/clientcredentials/connectrpc.go
+++ b/auth/clientcredentials/connectrpc.go
@@ -130,7 +130,7 @@ func (i *Interceptor) requireScope(ctx context.Context, headers http.Header, req
 		return nil, connectInternalError(ctx, i.logger, err, "unable to validate token")
 	}
 	if result.UserID != "" {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("SAT token not allowed"))
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("a user-scoped token is not allowed"))
 	}
 
 	span.SetAttributes(

--- a/auth/clientcredentials/connectrpc_test.go
+++ b/auth/clientcredentials/connectrpc_test.go
@@ -96,7 +96,7 @@ func TestInterceptor(t *testing.T) {
 			UserID:   "test-user",
 			Scopes:   scopes.Scopes{"profile"},
 		},
-		wantError: autogold.Expect("unauthenticated: SAT token not allowed"),
+		wantError: autogold.Expect("unauthenticated: a user-scoped token is not allowed"),
 		wantLogs:  autogold.Expect([]string{}),
 	}} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/auth/clientcredentials/connectrpc_test.go
+++ b/auth/clientcredentials/connectrpc_test.go
@@ -88,6 +88,16 @@ func TestInterceptor(t *testing.T) {
 		// client credentials token
 		wantError: autogold.Expect("permission_denied: permission denied"),
 		wantLogs:  autogold.Expect([]string{}),
+	}, {
+		name: "SAT token with userID rejected",
+		token: &sams.IntrospectTokenResponse{
+			Active:   true,
+			ClientID: "test-client",
+			UserID:   "test-user",
+			Scopes:   scopes.Scopes{"profile"},
+		},
+		wantError: autogold.Expect("unauthenticated: SAT token not allowed"),
+		wantLogs:  autogold.Expect([]string{}),
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			logger, exportLogs := logtest.Captured(t)

--- a/auth/clientcredentials/http.go
+++ b/auth/clientcredentials/http.go
@@ -68,6 +68,14 @@ func (a *HTTPAuthenticator) RequireScopes(requiredScopes scopes.Scopes, next htt
 			return
 		}
 
+		if result.UserID != "" {
+			logger.Warn("attempt to authenticate using SAMS token with user ID",
+				log.String("client", result.ClientID),
+				log.String("userID", result.UserID))
+			http.Error(w, "Forbidden: User tokens not allowed", http.StatusForbidden)
+			return
+		}
+
 		// Check for our required scope.
 		for _, required := range requiredScopes {
 			if !result.Scopes.Match(required) {

--- a/auth/clientcredentials/http_test.go
+++ b/auth/clientcredentials/http_test.go
@@ -52,6 +52,16 @@ func TestHTTPAuthenticator(t *testing.T) {
 		},
 		wantError: autogold.Expect("Forbidden: Missing required scope\n"),
 		wantLogs:  autogold.Expect([]string{"attempt to authenticate using SAMS token without required scope"}),
+	}, {
+		name: "SAT token with userID rejected",
+		token: &sams.IntrospectTokenResponse{
+			Active:   true,
+			ClientID: "test-client",
+			UserID:   "test-user",
+			Scopes:   scopes.Scopes{"profile"},
+		},
+		wantError: autogold.Expect("Forbidden: User tokens not allowed\n"),
+		wantLogs:  autogold.Expect([]string{"attempt to authenticate using SAMS token with user ID"}),
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			logger, exportLogs := logtest.Captured(t)


### PR DESCRIPTION
SAMS Service Access Tokens function similarly to M2M tokens. Both use the same introspectToken call to SAMS. For SATs the response includes the user the token is scoped to.

In the case where a SAT and M2M token both have the same scopes we need to prevent privilege escalation where a SAT could be supplied to a M2M RPC which would not be expected to properly enforce the user scoping.

This PR updates the client credentials middleware to fail the request if an introspected token as a non-empty user field.

Closes CORE-1126
## Test plan
CI