### PR TITLE
CloudAPI: add service and scopes

### DIFF
--- a/scopes/scopes.go
+++ b/scopes/scopes.go
@@ -135,6 +135,9 @@ var (
 	analyticsPermissions = []Permission{
 		"analytics",
 	}
+	cloudAPIPermissions = []Permission{
+		"instance",
+	}
 )
 
 const (
@@ -199,6 +202,7 @@ func Allowed() AllowedScopes {
 	appendScopes(services.MailGatekeeper, mailGatekeeperPermissions)
 	appendScopes(services.Workspaces, workspacesPermissions)
 	appendScopes(services.Analytics, analyticsPermissions)
+	appendScopes(services.CloudAPI, cloudAPIPermissions)
 	// 👉 ADD YOUR SCOPES HERE
 	return allowed
 }

--- a/scopes/scopes_test.go
+++ b/scopes/scopes_test.go
@@ -96,6 +96,9 @@ func TestAllowedGoldenList(t *testing.T) {
 		Scope("analytics::analytics::read"),
 		Scope("analytics::analytics::write"),
 		Scope("analytics::analytics::delete"),
+		Scope("cloud_api::instance::read"),
+		Scope("cloud_api::instance::write"),
+		Scope("cloud_api::instance::delete"),
 	}).Equal(t, Allowed())
 }
 

--- a/services/services.go
+++ b/services/services.go
@@ -15,6 +15,7 @@ const (
 	Workspaces       Service = "workspaces"
 	SSC              Service = "ssc"
 	Analytics        Service = "analytics"
+	CloudAPI         Service = "cloud_api"
 )
 
 var serviceNames = map[Service]string{
@@ -28,6 +29,7 @@ var serviceNames = map[Service]string{
 	Workspaces:       "Workspaces",
 	SSC:              "Self Serve Cody",
 	Analytics:        "Sourcegraph Analytics",
+	CloudAPI:         "Cloud API",
 }
 
 func (s Service) DisplayName() string {


### PR DESCRIPTION
Ref: [CLO-1776](https://linear.app/sourcegraph/issue/CLO-1776/extend-cloudapi-with-m2m-sams-authentication)
Add CloudAPI service and scopes.

## Test plan

Unit tests.