### PR TITLE
scopes: add enterprise_portal slack_integrations permission

### DIFF
--- a/scopes/scopes.go
+++ b/scopes/scopes.go
@@ -117,6 +117,7 @@ var (
 		PermissionEnterprisePortalSubscriptionPermission,
 		PermissionEnterprisePortalCodyAccess,
 		PermissionEnterprisePortalMetering,
+		PermissionEnterprisePortalSlackIntegrations,
 	}
 	workspacesPermissions = []Permission{
 		"workspace",
@@ -156,6 +157,12 @@ const (
 	// PermissionEnterprisePortalMetering designates permissions for Deep Search
 	// quota management and metering functionality.
 	PermissionEnterprisePortalMetering Permission = "metering"
+
+	// PermissionEnterprisePortalSlackIntegrations designates permissions for
+	// Enterprise Portal customer Slack notification integrations
+	// (enterpriseportal.slacknotifications.v1.SlackIntegrationsService),
+	// consumed by cloud-notifications over M2M.
+	PermissionEnterprisePortalSlackIntegrations Permission = "slack_integrations"
 )
 
 // Allowed returns all allowed scopes for a client. The caller should use

--- a/scopes/scopes_test.go
+++ b/scopes/scopes_test.go
@@ -75,6 +75,9 @@ func TestAllowedGoldenList(t *testing.T) {
 		Scope("enterprise_portal::metering::read"),
 		Scope("enterprise_portal::metering::write"),
 		Scope("enterprise_portal::metering::delete"),
+		Scope("enterprise_portal::slack_integrations::read"),
+		Scope("enterprise_portal::slack_integrations::write"),
+		Scope("enterprise_portal::slack_integrations::delete"),
 		Scope("workspaces::workspace::read"),
 		Scope("workspaces::workspace::write"),
 		Scope("workspaces::workspace::delete"),
@@ -117,6 +120,23 @@ func TestAllowed(t *testing.T) {
 			t.Run(string(test.scope), func(t *testing.T) {
 				got := allowedScopes.Contains(test.scope)
 				assert.Equal(t, test.allowed, got)
+			})
+		}
+	})
+
+	t.Run("slack_integrations", func(t *testing.T) {
+		tests := []struct {
+			scope   Scope
+			allowed bool
+		}{
+			{"enterprise_portal::slack_integrations::read", true},
+			{"enterprise_portal::slack_integrations::write", true},
+			{"enterprise_portal::slack_integrations::delete", true},
+			{"enterprise_portal::slack_integrations::bogus", false},
+		}
+		for _, test := range tests {
+			t.Run(string(test.scope), func(t *testing.T) {
+				assert.Equal(t, test.allowed, allowedScopes.Contains(test.scope))
 			})
 		}
 	})


### PR DESCRIPTION
## Summary
Adds the `slack_integrations` permission for Enterprise Portal's `SlackIntegrationsService`, with the standard `read`/`write`/`delete` actions. This permission is consumed over M2M by the new `cloud-notifications` service (PLAT-676 Slack notifications POC) to read a customer's Slack integration and write back broken-state.

- Adds `PermissionEnterprisePortalSlackIntegrations = "slack_integrations"` and registers it in `enterprisePortalPermissions`, so `scopes.Allowed()` emits `enterprise_portal::slack_integrations::{read,write,delete}`.
- Updates the golden scopes test.

## Why this is needed
SAMS validates client registrations against `scopes.Allowed()` (the server allow-list is compiled from this SDK). Until this lands and SAMS is bumped/redeployed, `sg sams client create --scopes enterprise_portal::slack_integrations::read` is rejected, and the cloud-notifications M2M client cannot be minted. This PR is the first step of: publish SDK → bump pin in sourcegraph-accounts → redeploy SAMS dev.

The EP-side enforcement uses `enterprise_portal::slack_integrations::read` (GetSlackIntegration) and `::write` (UpdateSlackIntegrationStatus).