### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.26.4
       - name: Enable pulling Go modules from private sourcegrahp/sourcegraph 
         run: git config --global url."https://${PRIVATE_TOKEN}@github.com/sourcegraph/".insteadOf "https://github.com/sourcegraph/"
       - name: Check Go module tidiness
@@ -53,7 +53,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [ 1.22.x ]
+        go-version: [ 1.26.4 ]
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.23.4
+golang 1.26.4

--- a/clientv1_test.go
+++ b/clientv1_test.go
@@ -5,7 +5,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/lib/pointers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -71,7 +70,7 @@ func TestParseResponseAndError(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := parseResponseAndError(connect.NewResponse(pointers.Ptr("foo")), test.err())
+			_, err := parseResponseAndError(connect.NewResponse(new("foo")), test.err())
 			if test.wantErr == "" {
 				assert.NoError(t, err)
 			} else {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/sourcegraph-accounts-sdk-go
 
-go 1.23.4
+go 1.26.4
 
 require (
 	cloud.google.com/go/pubsub v1.45.3


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)